### PR TITLE
Create codespace and dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// DevContainer: https://code.visualstudio.com/docs/remote/containers
+// This file is used to configure the dev container for the project, intended to contain Terraform, Terraform-Docs
+{
+    "name": "AWS-Terraform",
+    "image": "mcr.microsoft.com/vscode/devcontainers/base:ubuntu-22.04",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/aws-cli:1": {},
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": false,
+            "configureZshAsDefaultShell": true,
+            "installOhMyZsh": true,
+            "upgradePackages": true
+        },
+        "ghcr.io/devcontainers/features/git:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
+        "ghcr.io/devcontainers/features/terraform:1": {
+            "terragrunt": "none", // we don't want to install terragrunt
+            "installTerraformDocs": true
+        },
+        "ghcr.io/devcontainers-contrib/features/pre-commit:2": {}
+    },
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "amazonwebservices.aws-toolkit-vscode",
+                "hashicorp.terraform",
+                "streetsidesoftware.code-spell-checker",
+                "srmeyers.git-prefix",
+                "eamodio.gitlens",
+                "christian-kohler.path-intellisense",
+                "esbenp.prettier-vscode",
+                "Gruntfuggly.todo-tree",
+                "GitHub.copilot",
+                "GitHub.copilot-chat"
+            ],
+            "settings": {
+                "terraform.languageServer": {
+                    "enabled": true,
+                    "args": []
+                }
+            }
+        }
+    },
+    "remoteEnv": {
+        "TF_LOG": "info",
+        "TF_LOG_PATH": "./terraform.lo"
+    },
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root",
+    "remoteUser": "vscode",
+    "runArgs": [
+        "--cap-add=SYS_PTRACE",
+        "--security-opt",
+        "seccomp=unconfined"
+    ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+terraform.lo


### PR DESCRIPTION
This pull request adds the necessary configuration for creating a codespace and dev container. It includes the installation of AWS CLI v2, Terraform, Terraform-docs, and Pre-Commit. Additionally, it adds a devcontainer.json file and updates the .gitignore file to exclude terraform.lo. This resolves the issue #1.